### PR TITLE
fix(login): add 120s OAuth timeout to prevent hanging on failed auth

### DIFF
--- a/crates/lockit-cli/src/main.rs
+++ b/crates/lockit-cli/src/main.rs
@@ -124,7 +124,9 @@ fn main() -> anyhow::Result<()> {
             commands::show::run(&paths, cli.password, &name_or_id, json)
         }
         Commands::Edit { name_or_id } => commands::edit::run(&paths, cli.password, &name_or_id),
-        Commands::Delete { name_or_id, yes } => commands::delete::run(&paths, cli.password, &name_or_id, yes),
+        Commands::Delete { name_or_id, yes } => {
+            commands::delete::run(&paths, cli.password, &name_or_id, yes)
+        }
         Commands::Reveal { name_or_id, field } => {
             commands::reveal::run(&paths, cli.password, &name_or_id, &field)
         }

--- a/crates/lockit-core/src/sync/oauth.rs
+++ b/crates/lockit-core/src/sync/oauth.rs
@@ -57,9 +57,7 @@ pub fn start_oauth_flow() -> Result<OAuthTokens, String> {
     }
 
     // Set nonblocking so we can poll with a timeout
-    listener
-        .set_nonblocking(true)
-        .map_err(|e| format!("{e}"))?;
+    listener.set_nonblocking(true).map_err(|e| format!("{e}"))?;
 
     // Accept ONE connection, extract the auth code (120s timeout)
     let code = match wait_for_callback(&listener) {
@@ -96,7 +94,10 @@ fn wait_for_callback(listener: &TcpListener) -> Result<String, String> {
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 if start.elapsed() > timeout {
-                    return Err("OAuth login timed out after 120s. Browser did not complete authorization.".to_string());
+                    return Err(
+                        "OAuth login timed out after 120s. Browser did not complete authorization."
+                            .to_string(),
+                    );
                 }
                 std::thread::sleep(std::time::Duration::from_millis(200));
                 continue;

--- a/crates/lockit-core/src/sync/oauth.rs
+++ b/crates/lockit-core/src/sync/oauth.rs
@@ -85,7 +85,12 @@ fn wait_for_callback(listener: &TcpListener) -> Result<String, String> {
     let timeout = std::time::Duration::from_secs(120);
     let stream = loop {
         match listener.accept() {
-            Ok((stream, _)) => break stream,
+            Ok((stream, _)) => {
+                stream
+                    .set_nonblocking(false)
+                    .map_err(|e| format!("Failed to set stream blocking: {e}"))?;
+                break stream;
+            }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 if start.elapsed() > timeout {
                     return Err("OAuth login timed out after 120s. Browser did not complete authorization.".to_string());

--- a/crates/lockit-core/src/sync/oauth.rs
+++ b/crates/lockit-core/src/sync/oauth.rs
@@ -89,6 +89,9 @@ fn wait_for_callback(listener: &TcpListener) -> Result<String, String> {
                 stream
                     .set_nonblocking(false)
                     .map_err(|e| format!("Failed to set stream blocking: {e}"))?;
+                stream
+                    .set_read_timeout(Some(timeout))
+                    .map_err(|e| format!("Failed to set read timeout: {e}"))?;
                 break stream;
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {

--- a/crates/lockit-core/src/sync/oauth.rs
+++ b/crates/lockit-core/src/sync/oauth.rs
@@ -56,13 +56,24 @@ pub fn start_oauth_flow() -> Result<OAuthTokens, String> {
         eprintln!("Browser opened. Authorize the app and return here.");
     }
 
-    // Set a read timeout so we don't block forever
+    // Set nonblocking so we can poll with a timeout
     listener
-        .set_nonblocking(false)
+        .set_nonblocking(true)
         .map_err(|e| format!("{e}"))?;
 
-    // Accept ONE connection, extract the auth code
-    let code = wait_for_callback(&listener)?;
+    // Accept ONE connection, extract the auth code (120s timeout)
+    let code = match wait_for_callback(&listener) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "OAuth login timed out or failed.\n\
+                 If the client ID is invalid, set LOCKIT_GOOGLE_CLIENT_ID env var.\n\
+                 Or configure manually: lockit sync config\n\
+                 Error: {e}"
+            );
+            return Err(e);
+        }
+    };
     drop(listener);
 
     // Exchange code for tokens
@@ -70,11 +81,24 @@ pub fn start_oauth_flow() -> Result<OAuthTokens, String> {
 }
 
 fn wait_for_callback(listener: &TcpListener) -> Result<String, String> {
-    let (mut stream, _) = listener
-        .accept()
-        .map_err(|e| format!("Connection error: {e}"))?;
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(120);
+    let stream = loop {
+        match listener.accept() {
+            Ok((stream, _)) => break stream,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if start.elapsed() > timeout {
+                    return Err("OAuth login timed out after 120s. Browser did not complete authorization.".to_string());
+                }
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                continue;
+            }
+            Err(e) => return Err(format!("Connection error: {e}")),
+        }
+    };
 
     let mut reader = BufReader::new(stream.try_clone().map_err(|e| format!("{e}"))?);
+    let mut stream = stream;
     let mut request_line = String::new();
     reader
         .read_line(&mut request_line)


### PR DESCRIPTION
## Summary
- **Fixes #16**: OAuth login no longer hangs forever on failed auth
- Nonblocking `accept()` with 120s poll loop + timeout
- Clear error message with guidance: `LOCKIT_GOOGLE_CLIENT_ID` or `lockit sync config`

## Test plan
- [ ] `cargo build` zero warnings
- [ ] `cargo clippy` clean
- [ ] `cargo test` 14/14 pass
- [ ] Failed login exits with timeout error after 120s
- [ ] Error message suggests LOCKIT_GOOGLE_CLIENT_ID or sync config