### PR TITLE
fix(oauth): update default credentials and add client_secret support

### DIFF
--- a/crates/lockit-cli/src/commands/login.rs
+++ b/crates/lockit-cli/src/commands/login.rs
@@ -24,7 +24,7 @@ pub fn run(paths: &lockit_core::vault::VaultPaths) -> anyhow::Result<()> {
         refresh_token: tokens.refresh_token,
         token_expiry: now + tokens.expires_in,
         client_id: oauth::google_client_id(),
-        client_secret: String::new(),
+        client_secret: oauth::google_client_secret(),
     };
 
     let vault_dir = paths

--- a/crates/lockit-core/src/sync/oauth.rs
+++ b/crates/lockit-core/src/sync/oauth.rs
@@ -13,7 +13,7 @@ const GOOGLE_REDIRECT_PORT: u16 = 0; // 0 = OS picks a random port
 pub const GOOGLE_CLIENT_ID_DEFAULT: &str =
     "927834600586-oe5f5dff4jklbdu5mv7ahu612l3i2bc1.apps.googleusercontent.com";
 
-pub const GOOGLE_CLIENT_SECRET_DEFAULT: &str = "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";
+pub const GOOGLE_CLIENT_SECRET_DEFAULT: &str = "";
 
 pub fn google_client_id() -> String {
     std::env::var("LOCKIT_GOOGLE_CLIENT_ID")
@@ -154,16 +154,19 @@ fn exchange_code(
     let cid = google_client_id();
     let secret = google_client_secret();
     let client = reqwest::blocking::Client::new();
+    let mut params: Vec<(&str, &str)> = vec![
+        ("client_id", cid.as_str()),
+        ("code", code),
+        ("code_verifier", code_verifier),
+        ("redirect_uri", redirect_uri),
+        ("grant_type", "authorization_code"),
+    ];
+    if !secret.is_empty() {
+        params.push(("client_secret", secret.as_str()));
+    }
     let resp = client
         .post(GOOGLE_TOKEN_URL)
-        .form(&[
-            ("client_id", cid.as_str()),
-            ("client_secret", secret.as_str()),
-            ("code", code),
-            ("code_verifier", code_verifier),
-            ("redirect_uri", redirect_uri),
-            ("grant_type", "authorization_code"),
-        ])
+        .form(&params)
         .send()
         .map_err(|e| format!("Token request failed: {e}"))?;
 

--- a/crates/lockit-core/src/sync/oauth.rs
+++ b/crates/lockit-core/src/sync/oauth.rs
@@ -13,7 +13,7 @@ const GOOGLE_REDIRECT_PORT: u16 = 0; // 0 = OS picks a random port
 pub const GOOGLE_CLIENT_ID_DEFAULT: &str =
     "927834600586-oe5f5dff4jklbdu5mv7ahu612l3i2bc1.apps.googleusercontent.com";
 
-pub const GOOGLE_CLIENT_SECRET_DEFAULT: &str = "";
+pub const GOOGLE_CLIENT_SECRET_DEFAULT: &str = "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";
 
 pub fn google_client_id() -> String {
     std::env::var("LOCKIT_GOOGLE_CLIENT_ID")
@@ -154,19 +154,16 @@ fn exchange_code(
     let cid = google_client_id();
     let secret = google_client_secret();
     let client = reqwest::blocking::Client::new();
-    let mut params: Vec<(&str, &str)> = vec![
-        ("client_id", cid.as_str()),
-        ("code", code),
-        ("code_verifier", code_verifier),
-        ("redirect_uri", redirect_uri),
-        ("grant_type", "authorization_code"),
-    ];
-    if !secret.is_empty() {
-        params.push(("client_secret", secret.as_str()));
-    }
     let resp = client
         .post(GOOGLE_TOKEN_URL)
-        .form(&params)
+        .form(&[
+            ("client_id", cid.as_str()),
+            ("client_secret", secret.as_str()),
+            ("code", code),
+            ("code_verifier", code_verifier),
+            ("redirect_uri", redirect_uri),
+            ("grant_type", "authorization_code"),
+        ])
         .send()
         .map_err(|e| format!("Token request failed: {e}"))?;
 

--- a/crates/lockit-core/src/sync/oauth.rs
+++ b/crates/lockit-core/src/sync/oauth.rs
@@ -11,12 +11,20 @@ const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 const GOOGLE_REDIRECT_PORT: u16 = 0; // 0 = OS picks a random port
 
 pub const GOOGLE_CLIENT_ID_DEFAULT: &str =
-    "1067183645292-2dshqcfq5jfraokjn4p8davhgkponfua.apps.googleusercontent.com";
+    "927834600586-oe5f5dff4jklbdu5mv7ahu612l3i2bc1.apps.googleusercontent.com";
+
+pub const GOOGLE_CLIENT_SECRET_DEFAULT: &str = "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";
 
 pub fn google_client_id() -> String {
     std::env::var("LOCKIT_GOOGLE_CLIENT_ID")
         .unwrap_or_else(|_| GOOGLE_CLIENT_ID_DEFAULT.to_string())
 }
+
+pub fn google_client_secret() -> String {
+    std::env::var("LOCKIT_GOOGLE_CLIENT_SECRET")
+        .unwrap_or_else(|_| GOOGLE_CLIENT_SECRET_DEFAULT.to_string())
+}
+
 const GOOGLE_DRIVE_SCOPE: &str = "https://www.googleapis.com/auth/drive.appdata";
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -144,11 +152,13 @@ fn exchange_code(
     redirect_uri: &str,
 ) -> Result<OAuthTokens, String> {
     let cid = google_client_id();
+    let secret = google_client_secret();
     let client = reqwest::blocking::Client::new();
     let resp = client
         .post(GOOGLE_TOKEN_URL)
         .form(&[
             ("client_id", cid.as_str()),
+            ("client_secret", secret.as_str()),
             ("code", code),
             ("code_verifier", code_verifier),
             ("redirect_uri", redirect_uri),


### PR DESCRIPTION
## Summary
- **Fixes #19**: Replace broken OAuth client ID and add client_secret
- Desktop OAuth requires client_secret in token exchange
- `LOCKIT_GOOGLE_CLIENT_ID` and `LOCKIT_GOOGLE_CLIENT_SECRET` env overrides

## Test plan
- [ ] `cargo build` zero warnings
- [ ] `cargo clippy` clean
- [ ] `cargo test` 14/14 pass
- [ ] `lockit login` with new default credentials completes OAuth flow