### PR TITLE
feat(sync): add sync key encryption for cross-platform compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "serde_json",
  "tabled",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/lockit-cli/Cargo.toml
+++ b/crates/lockit-cli/Cargo.toml
@@ -17,6 +17,7 @@ rpassword = "7"
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
 tabled = "0.16"
+zeroize.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lockit-cli/src/commands/login.rs
+++ b/crates/lockit-cli/src/commands/login.rs
@@ -25,6 +25,7 @@ pub fn run(paths: &lockit_core::vault::VaultPaths) -> anyhow::Result<()> {
         token_expiry: now + tokens.expires_in,
         client_id: oauth::google_client_id(),
         client_secret: oauth::google_client_secret(),
+        sync_key: None,
     };
 
     let vault_dir = paths

--- a/crates/lockit-cli/src/commands/login.rs
+++ b/crates/lockit-cli/src/commands/login.rs
@@ -19,13 +19,21 @@ pub fn run(paths: &lockit_core::vault::VaultPaths) -> anyhow::Result<()> {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
+    // Preserve existing sync key if already configured
+    let existing_key = std::fs::read_to_string(
+        paths.vault_path.with_file_name("sync_config.json"),
+    )
+    .ok()
+    .and_then(|s| serde_json::from_str::<GoogleDriveConfig>(&s).ok())
+    .and_then(|c| c.sync_key);
+
     let cfg = GoogleDriveConfig {
         access_token: tokens.access_token,
         refresh_token: tokens.refresh_token,
         token_expiry: now + tokens.expires_in,
         client_id: oauth::google_client_id(),
         client_secret: oauth::google_client_secret(),
-        sync_key: None,
+        sync_key: existing_key,
     };
 
     let vault_dir = paths

--- a/crates/lockit-cli/src/commands/sync_cmd.rs
+++ b/crates/lockit-cli/src/commands/sync_cmd.rs
@@ -25,6 +25,16 @@ fn load_backend(paths: &VaultPaths) -> GoogleDriveBackend {
     backend
 }
 
+fn load_sync_config(paths: &VaultPaths) -> Option<GoogleDriveConfig> {
+    let cfg_path = config_path(paths);
+    if cfg_path.exists() {
+        if let Ok(data) = std::fs::read_to_string(&cfg_path) {
+            return serde_json::from_str::<GoogleDriveConfig>(&data).ok();
+        }
+    }
+    None
+}
+
 fn save_config(paths: &VaultPaths, config: &GoogleDriveConfig) -> anyhow::Result<()> {
     let cfg_path = config_path(paths);
     if let Some(parent) = cfg_path.parent() {
@@ -79,13 +89,25 @@ pub fn push(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
         lockit_core::vault::unlock_vault(paths, &_pw).context("Failed to unlock vault")?;
 
     let vault_bytes = std::fs::read(&paths.vault_path).context("Failed to read vault file")?;
-    let checksum = sha256_checksum(&vault_bytes);
-    let encrypted_size = vault_bytes.len() as u64;
+
+    // Encrypt with sync key if configured (cross-platform compatible)
+    let sync_config = load_sync_config(paths);
+    let upload_bytes = if let Some(ref key_b64) = sync_config.and_then(|c| c.sync_key) {
+        let sync_key = lockit_core::sync::SyncCrypto::decode_key(key_b64)
+            .map_err(|e| anyhow::anyhow!("Invalid sync key: {e}"))?;
+        lockit_core::sync::SyncCrypto::encrypt(&vault_bytes, &sync_key)
+            .map_err(|e| anyhow::anyhow!("Sync encryption failed: {e}"))?
+    } else {
+        vault_bytes
+    };
+
+    let checksum = sha256_checksum(&upload_bytes);
+    let encrypted_size = upload_bytes.len() as u64;
 
     let manifest = SyncManifest::new(checksum, "lockit-cli", encrypted_size, 2);
 
     backend
-        .upload_vault(&vault_bytes, &manifest)
+        .upload_vault(&upload_bytes, &manifest)
         .map_err(|e| anyhow::anyhow!("Upload failed: {e}"))?;
 
     crate::output::success("Vault pushed to cloud.");
@@ -98,6 +120,16 @@ pub fn pull(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
         anyhow::bail!("Sync backend not configured. Run 'lockit sync config' first.");
     }
 
+    let sync_config = load_sync_config(paths);
+    let sync_key: Option<[u8; 32]> = sync_config
+        .as_ref()
+        .and_then(|c| c.sync_key.as_ref())
+        .map(|k| {
+            lockit_core::sync::SyncCrypto::decode_key(k)
+                .map_err(|e| anyhow::anyhow!("Invalid sync key: {e}"))
+        })
+        .transpose()?;
+
     // Fetch manifest first — cheap metadata, no large download yet
     let cloud_manifest = backend
         .get_manifest()
@@ -105,18 +137,24 @@ pub fn pull(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
         .context("No manifest found in cloud")?;
     let cloud_checksum = &cloud_manifest.vault_checksum;
 
-    // Early-return if already up to date — skip password check and download
+    // Early-return if already up to date
     if paths.vault_path.exists() {
         let local_bytes =
             std::fs::read(&paths.vault_path).context("Failed to read local vault file")?;
-        let local_checksum = sha256_checksum(&local_bytes);
+        let local_checksum = if let Some(ref key) = sync_key {
+            let encrypted = lockit_core::sync::SyncCrypto::encrypt(&local_bytes, key)
+                .context("Failed to encrypt for checksum comparison")?;
+            sha256_checksum(&encrypted)
+        } else {
+            sha256_checksum(&local_bytes)
+        };
         if local_checksum == *cloud_checksum {
             crate::output::success("Already up to date.");
             return Ok(());
         }
     }
 
-    // Validate password before network download — fail fast
+    // Validate password before network download
     if let Some(p) = pw {
         lockit_core::vault::unlock_vault(paths, &p).context("Failed to unlock vault")?;
     }
@@ -125,7 +163,7 @@ pub fn pull(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
         .download_vault()
         .map_err(|e| anyhow::anyhow!("Download failed: {e}"))?;
 
-    // Verify downloaded data matches the manifest checksum
+    // Verify checksum
     let downloaded_checksum = sha256_checksum(&cloud_bytes);
     if downloaded_checksum != *cloud_checksum {
         anyhow::bail!(
@@ -135,7 +173,15 @@ pub fn pull(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
         );
     }
 
-    std::fs::write(&paths.vault_path, &cloud_bytes).context("Failed to write vault file")?;
+    // Decrypt with sync key if configured
+    let vault_bytes = if let Some(ref key) = sync_key {
+        lockit_core::sync::SyncCrypto::decrypt(&cloud_bytes, key)
+            .map_err(|e| anyhow::anyhow!("Sync decryption failed: {e}"))?
+    } else {
+        cloud_bytes
+    };
+
+    std::fs::write(&paths.vault_path, &vault_bytes).context("Failed to write vault file")?;
 
     crate::output::success("Vault pulled from cloud.");
     Ok(())
@@ -173,6 +219,7 @@ pub fn config(paths: &VaultPaths) -> anyhow::Result<()> {
         refresh_token: refresh_token.trim().to_string(),
         access_token: access_token.trim().to_string(),
         token_expiry: 0,
+        sync_key: None,
     };
 
     // Save config to file next to vault
@@ -183,6 +230,31 @@ pub fn config(paths: &VaultPaths) -> anyhow::Result<()> {
         "Sync configuration saved to {}",
         cfg_path.display()
     ));
+
+    Ok(())
+}
+
+pub fn key_gen(paths: &VaultPaths) -> anyhow::Result<()> {
+    let key = lockit_core::sync::SyncCrypto::generate_key();
+    let encoded = lockit_core::sync::SyncCrypto::encode_key(&key);
+
+    let mut config = load_sync_config(paths).unwrap_or(GoogleDriveConfig {
+        access_token: String::new(),
+        refresh_token: String::new(),
+        token_expiry: 0,
+        client_id: String::new(),
+        client_secret: String::new(),
+        sync_key: None,
+    });
+    config.sync_key = Some(encoded.clone());
+    save_config(paths, &config)?;
+
+    println!("Sync key generated and saved.");
+    println!();
+    println!("Key (Base64): {encoded}");
+    println!();
+    println!("Share this key with other devices to sync the same vault.");
+    println!("Keep it secret — anyone with this key can decrypt your synced data.");
 
     Ok(())
 }

--- a/crates/lockit-cli/src/commands/sync_cmd.rs
+++ b/crates/lockit-cli/src/commands/sync_cmd.rs
@@ -27,12 +27,19 @@ fn load_backend(paths: &VaultPaths) -> GoogleDriveBackend {
 
 fn load_sync_config(paths: &VaultPaths) -> Option<GoogleDriveConfig> {
     let cfg_path = config_path(paths);
-    if cfg_path.exists() {
-        if let Ok(data) = std::fs::read_to_string(&cfg_path) {
-            return serde_json::from_str::<GoogleDriveConfig>(&data).ok();
-        }
+    let data = std::fs::read_to_string(&cfg_path).ok()?;
+    serde_json::from_str::<GoogleDriveConfig>(&data).ok()
+}
+
+fn empty_sync_config() -> GoogleDriveConfig {
+    GoogleDriveConfig {
+        access_token: String::new(),
+        refresh_token: String::new(),
+        token_expiry: 0,
+        client_id: lockit_core::sync::oauth::google_client_id(),
+        client_secret: lockit_core::sync::oauth::google_client_secret(),
+        sync_key: None,
     }
-    None
 }
 
 fn save_config(paths: &VaultPaths, config: &GoogleDriveConfig) -> anyhow::Result<()> {
@@ -237,14 +244,7 @@ pub fn key_gen(paths: &VaultPaths) -> anyhow::Result<()> {
     let key = lockit_core::sync::SyncCrypto::generate_key();
     let encoded = lockit_core::sync::SyncCrypto::encode_key(&key);
 
-    let mut config = load_sync_config(paths).unwrap_or(GoogleDriveConfig {
-        access_token: String::new(),
-        refresh_token: String::new(),
-        token_expiry: 0,
-        client_id: String::new(),
-        client_secret: String::new(),
-        sync_key: None,
-    });
+    let mut config = load_sync_config(paths).unwrap_or_else(empty_sync_config);
     config.sync_key = Some(encoded);
     save_config(paths, &config)?;
 
@@ -272,14 +272,7 @@ pub fn key_set(paths: &VaultPaths) -> anyhow::Result<()> {
     lockit_core::sync::SyncCrypto::decode_key(key)
         .map_err(|e| anyhow::anyhow!("Invalid sync key: {e}"))?;
 
-    let mut config = load_sync_config(paths).unwrap_or(GoogleDriveConfig {
-        access_token: String::new(),
-        refresh_token: String::new(),
-        token_expiry: 0,
-        client_id: String::new(),
-        client_secret: String::new(),
-        sync_key: None,
-    });
+    let mut config = load_sync_config(paths).unwrap_or_else(empty_sync_config);
     config.sync_key = Some(key.to_string());
     save_config(paths, &config)?;
 

--- a/crates/lockit-cli/src/commands/sync_cmd.rs
+++ b/crates/lockit-cli/src/commands/sync_cmd.rs
@@ -92,7 +92,7 @@ pub fn push(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
 
     // Encrypt with sync key if configured (cross-platform compatible)
     let sync_config = load_sync_config(paths);
-    let upload_bytes = if let Some(ref key_b64) = sync_config.and_then(|c| c.sync_key) {
+    let upload_bytes = if let Some(ref key_b64) = sync_config.as_ref().and_then(|c| c.sync_key.as_ref()) {
         let sync_key = lockit_core::sync::SyncCrypto::decode_key(key_b64)
             .map_err(|e| anyhow::anyhow!("Invalid sync key: {e}"))?;
         lockit_core::sync::SyncCrypto::encrypt(&vault_bytes, &sync_key)
@@ -103,8 +103,9 @@ pub fn push(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
 
     let checksum = sha256_checksum(&upload_bytes);
     let encrypted_size = upload_bytes.len() as u64;
+    let schema_version = if sync_config.as_ref().and_then(|c| c.sync_key.as_ref()).is_some() { 2 } else { 1 };
 
-    let manifest = SyncManifest::new(checksum, "lockit-cli", encrypted_size, 2);
+    let manifest = SyncManifest::new(checksum, "lockit-cli", encrypted_size, schema_version);
 
     backend
         .upload_vault(&upload_bytes, &manifest)
@@ -137,17 +138,11 @@ pub fn pull(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
         .context("No manifest found in cloud")?;
     let cloud_checksum = &cloud_manifest.vault_checksum;
 
-    // Early-return if already up to date
-    if paths.vault_path.exists() {
+    // Early-return if already up to date (non-sync-key only — sync key random nonce prevents matching)
+    if paths.vault_path.exists() && sync_key.is_none() {
         let local_bytes =
             std::fs::read(&paths.vault_path).context("Failed to read local vault file")?;
-        let local_checksum = if let Some(ref key) = sync_key {
-            let encrypted = lockit_core::sync::SyncCrypto::encrypt(&local_bytes, key)
-                .context("Failed to encrypt for checksum comparison")?;
-            sha256_checksum(&encrypted)
-        } else {
-            sha256_checksum(&local_bytes)
-        };
+        let local_checksum = sha256_checksum(&local_bytes);
         if local_checksum == *cloud_checksum {
             crate::output::success("Already up to date.");
             return Ok(());
@@ -173,12 +168,16 @@ pub fn pull(paths: &VaultPaths, pw: Option<String>) -> anyhow::Result<()> {
         );
     }
 
-    // Decrypt with sync key if configured
-    let vault_bytes = if let Some(ref key) = sync_key {
-        lockit_core::sync::SyncCrypto::decrypt(&cloud_bytes, key)
-            .map_err(|e| anyhow::anyhow!("Sync decryption failed: {e}"))?
-    } else {
-        cloud_bytes
+    // Decrypt if cloud vault is sync-key encrypted (schema >= 2)
+    let vault_bytes = match cloud_manifest.schema_version {
+        v if v >= 2 => {
+            let key = sync_key.ok_or_else(|| {
+                anyhow::anyhow!("Cloud vault is encrypted with a sync key, but none is configured locally. Use 'lockit sync key-set <KEY>' first.")
+            })?;
+            lockit_core::sync::SyncCrypto::decrypt(&cloud_bytes, &key)
+                .map_err(|e| anyhow::anyhow!("Sync decryption failed: {e}"))?
+        }
+        _ => cloud_bytes,
     };
 
     std::fs::write(&paths.vault_path, &vault_bytes).context("Failed to write vault file")?;
@@ -255,6 +254,30 @@ pub fn key_gen(paths: &VaultPaths) -> anyhow::Result<()> {
     println!();
     println!("Share this key with other devices to sync the same vault.");
     println!("Keep it secret — anyone with this key can decrypt your synced data.");
+    println!();
+    println!("On Android: Config → Sync → paste this key.");
+
+    Ok(())
+}
+
+pub fn key_set(paths: &VaultPaths, key: &str) -> anyhow::Result<()> {
+    // Validate the key format
+    lockit_core::sync::SyncCrypto::decode_key(key)
+        .map_err(|e| anyhow::anyhow!("Invalid sync key: {e}"))?;
+
+    let mut config = load_sync_config(paths).unwrap_or(GoogleDriveConfig {
+        access_token: String::new(),
+        refresh_token: String::new(),
+        token_expiry: 0,
+        client_id: String::new(),
+        client_secret: String::new(),
+        sync_key: None,
+    });
+    config.sync_key = Some(key.trim().to_string());
+    save_config(paths, &config)?;
+
+    crate::output::success("Sync key configured.");
+    println!("Push and pull will now use this key for cross-platform sync.");
 
     Ok(())
 }

--- a/crates/lockit-cli/src/commands/sync_cmd.rs
+++ b/crates/lockit-cli/src/commands/sync_cmd.rs
@@ -5,6 +5,7 @@ use lockit_core::sync::{
 };
 use lockit_core::vault::VaultPaths;
 use std::path::PathBuf;
+use zeroize::Zeroize;
 
 fn config_path(paths: &VaultPaths) -> PathBuf {
     let mut p = paths.vault_path.clone();
@@ -241,8 +242,9 @@ pub fn config(paths: &VaultPaths) -> anyhow::Result<()> {
 }
 
 pub fn key_gen(paths: &VaultPaths) -> anyhow::Result<()> {
-    let key = lockit_core::sync::SyncCrypto::generate_key();
+    let mut key = lockit_core::sync::SyncCrypto::generate_key();
     let encoded = lockit_core::sync::SyncCrypto::encode_key(&key);
+    key.zeroize();
 
     let mut config = load_sync_config(paths).unwrap_or_else(empty_sync_config);
     config.sync_key = Some(encoded);

--- a/crates/lockit-cli/src/commands/sync_cmd.rs
+++ b/crates/lockit-cli/src/commands/sync_cmd.rs
@@ -267,16 +267,17 @@ pub fn key_show(paths: &VaultPaths) -> anyhow::Result<()> {
 }
 
 pub fn key_set(paths: &VaultPaths) -> anyhow::Result<()> {
-    let key = rpassword::prompt_password("Sync key (Base64): ")
+    let mut key = rpassword::prompt_password("Sync key (Base64): ")
         .context("Failed to read sync key")?;
-    let key = key.trim();
 
-    lockit_core::sync::SyncCrypto::decode_key(key)
+    lockit_core::sync::SyncCrypto::decode_key(key.trim())
         .map_err(|e| anyhow::anyhow!("Invalid sync key: {e}"))?;
 
     let mut config = load_sync_config(paths).unwrap_or_else(empty_sync_config);
-    config.sync_key = Some(key.to_string());
-    save_config(paths, &config)?;
+    config.sync_key = Some(key.trim().to_string());
+    let result = save_config(paths, &config);
+    key.zeroize();
+    result?;
 
     crate::output::success("Sync key configured.");
     println!("Push and pull will now use this key for cross-platform sync.");

--- a/crates/lockit-cli/src/commands/sync_cmd.rs
+++ b/crates/lockit-cli/src/commands/sync_cmd.rs
@@ -218,7 +218,7 @@ pub fn config(paths: &VaultPaths) -> anyhow::Result<()> {
         refresh_token: refresh_token.trim().to_string(),
         access_token: access_token.trim().to_string(),
         token_expiry: 0,
-        sync_key: None,
+        sync_key: load_sync_config(paths).and_then(|c| c.sync_key),
     };
 
     // Save config to file next to vault
@@ -245,23 +245,30 @@ pub fn key_gen(paths: &VaultPaths) -> anyhow::Result<()> {
         client_secret: String::new(),
         sync_key: None,
     });
-    config.sync_key = Some(encoded.clone());
+    config.sync_key = Some(encoded);
     save_config(paths, &config)?;
 
-    println!("Sync key generated and saved.");
-    println!();
-    println!("Key (Base64): {encoded}");
-    println!();
-    println!("Share this key with other devices to sync the same vault.");
-    println!("Keep it secret — anyone with this key can decrypt your synced data.");
-    println!();
-    println!("On Android: Config → Sync → paste this key.");
+    crate::output::success("Sync key generated and saved.");
+    println!("Use 'lockit sync key-show' to reveal the key for cross-platform setup.");
 
     Ok(())
 }
 
-pub fn key_set(paths: &VaultPaths, key: &str) -> anyhow::Result<()> {
-    // Validate the key format
+pub fn key_show(paths: &VaultPaths) -> anyhow::Result<()> {
+    let config = load_sync_config(paths)
+        .ok_or_else(|| anyhow::anyhow!("No sync configuration found."))?;
+    let key = config
+        .sync_key
+        .ok_or_else(|| anyhow::anyhow!("No sync key configured. Run 'lockit sync key-gen' first."))?;
+    println!("{key}");
+    Ok(())
+}
+
+pub fn key_set(paths: &VaultPaths) -> anyhow::Result<()> {
+    let key = rpassword::prompt_password("Sync key (Base64): ")
+        .context("Failed to read sync key")?;
+    let key = key.trim();
+
     lockit_core::sync::SyncCrypto::decode_key(key)
         .map_err(|e| anyhow::anyhow!("Invalid sync key: {e}"))?;
 
@@ -273,7 +280,7 @@ pub fn key_set(paths: &VaultPaths, key: &str) -> anyhow::Result<()> {
         client_secret: String::new(),
         sync_key: None,
     });
-    config.sync_key = Some(key.trim().to_string());
+    config.sync_key = Some(key.to_string());
     save_config(paths, &config)?;
 
     crate::output::success("Sync key configured.");

--- a/crates/lockit-cli/src/main.rs
+++ b/crates/lockit-cli/src/main.rs
@@ -102,6 +102,8 @@ enum SyncCmd {
     Push,
     Pull,
     Config,
+    #[command(about = "Generate a new sync key for cross-platform sync")]
+    KeyGen,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -141,6 +143,7 @@ fn main() -> anyhow::Result<()> {
             SyncCmd::Push => commands::sync_cmd::push(&paths, cli.password),
             SyncCmd::Pull => commands::sync_cmd::pull(&paths, cli.password),
             SyncCmd::Config => commands::sync_cmd::config(&paths),
+            SyncCmd::KeyGen => commands::sync_cmd::key_gen(&paths),
         },
         Commands::Env { name } => commands::env_cmd::run(&paths, cli.password, &name),
         Commands::Run { name, cmd } => commands::run_cmd::run(&paths, cli.password, &name, &cmd),

--- a/crates/lockit-cli/src/main.rs
+++ b/crates/lockit-cli/src/main.rs
@@ -104,8 +104,10 @@ enum SyncCmd {
     Config,
     #[command(about = "Generate a new sync key for cross-platform sync")]
     KeyGen,
-    #[command(about = "Set sync key from Android (paste Base64 key)")]
-    KeySet { key: String },
+    #[command(about = "Set sync key from Android (prompts securely)")]
+    KeySet,
+    #[command(about = "Show current sync key for sharing")]
+    KeyShow,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -146,7 +148,8 @@ fn main() -> anyhow::Result<()> {
             SyncCmd::Pull => commands::sync_cmd::pull(&paths, cli.password),
             SyncCmd::Config => commands::sync_cmd::config(&paths),
             SyncCmd::KeyGen => commands::sync_cmd::key_gen(&paths),
-            SyncCmd::KeySet { key } => commands::sync_cmd::key_set(&paths, &key),
+            SyncCmd::KeySet => commands::sync_cmd::key_set(&paths),
+            SyncCmd::KeyShow => commands::sync_cmd::key_show(&paths),
         },
         Commands::Env { name } => commands::env_cmd::run(&paths, cli.password, &name),
         Commands::Run { name, cmd } => commands::run_cmd::run(&paths, cli.password, &name, &cmd),

--- a/crates/lockit-cli/src/main.rs
+++ b/crates/lockit-cli/src/main.rs
@@ -104,6 +104,8 @@ enum SyncCmd {
     Config,
     #[command(about = "Generate a new sync key for cross-platform sync")]
     KeyGen,
+    #[command(about = "Set sync key from Android (paste Base64 key)")]
+    KeySet { key: String },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -144,6 +146,7 @@ fn main() -> anyhow::Result<()> {
             SyncCmd::Pull => commands::sync_cmd::pull(&paths, cli.password),
             SyncCmd::Config => commands::sync_cmd::config(&paths),
             SyncCmd::KeyGen => commands::sync_cmd::key_gen(&paths),
+            SyncCmd::KeySet { key } => commands::sync_cmd::key_set(&paths, &key),
         },
         Commands::Env { name } => commands::env_cmd::run(&paths, cli.password, &name),
         Commands::Run { name, cmd } => commands::run_cmd::run(&paths, cli.password, &name, &cmd),

--- a/crates/lockit-core/src/sync/google_drive.rs
+++ b/crates/lockit-core/src/sync/google_drive.rs
@@ -12,6 +12,8 @@ pub struct GoogleDriveConfig {
     pub token_expiry: i64,
     pub client_id: String,
     pub client_secret: String,
+    #[serde(default)]
+    pub sync_key: Option<String>,
 }
 
 /// A [`SyncBackend`] implementation that stores the encrypted vault and


### PR DESCRIPTION
## Summary
Add SyncCrypto encryption to CLI push/pull so both lockit-cli and lockit-android use the same sync key encryption for cross-platform cloud sync.

## Changes
- **Push**: encrypt vault bytes with sync key before upload (if configured)
- **Pull**: decrypt with sync key after download (if configured)
- **New command**: `lockit sync key-gen` generates a sync key
- **Checksum**: computed on encrypted blob (matching Android)
- **Backward compatible**: without sync key, raw vault bytes uploaded

## Test plan
- [ ] `cargo build` zero warnings
- [ ] `cargo test` 14/14 pass
- [ ] `lockit sync key-gen` generates and saves key
- [ ] Push with sync key → encrypted blob on Drive
- [ ] Pull with sync key → decrypts correctly